### PR TITLE
管理画面（取得数）の修正

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -148,7 +148,7 @@ class AdminApp {
             }
 
             // Get user count for this coupon
-            const userCount = this.getUserCount(coupon.id);
+            const userCount = coupon.user_count || 0;
 
             row.innerHTML = `
                 <td>${coupon.shop_name}</td>
@@ -169,11 +169,6 @@ class AdminApp {
 
             tbody.appendChild(row);
         });
-    }
-
-    getUserCount(couponId) {
-        // This is a placeholder. In a real app, this would come from the API
-        return Math.floor(Math.random() * 10);
     }
 
     formatDate(dateString) {

--- a/backend/main.py
+++ b/backend/main.py
@@ -311,10 +311,23 @@ async def create_coupon(request: CreateCouponRequest, db: Session = Depends(get_
 
 @app.get("/api/admin/coupons")
 async def get_all_coupons(db: Session = Depends(get_db)) -> List[dict]:
-    """Get all coupons with admin view"""
+    """Get all coupons with admin view including user counts"""
     coupon_repo = CouponRepository(db)
+    user_coupon_repo = UserCouponRepository(db)
+    
     db_coupons = coupon_repo.get_all_coupons()
-    return [db_coupon_to_dict(coupon) for coupon in db_coupons]
+    result = []
+    
+    for db_coupon in db_coupons:
+        # 各クーポンの取得ユーザー数を計算
+        obtained_users = user_coupon_repo.get_coupon_users(db_coupon.id)
+        user_count = len(obtained_users)
+        
+        coupon_dict = db_coupon_to_dict(db_coupon)
+        coupon_dict["user_count"] = user_count  # 追加
+        result.append(coupon_dict)
+    
+    return result
 
 @app.get("/api/admin/coupons/{coupon_id}")
 async def get_coupon_details(coupon_id: str, db: Session = Depends(get_db)):


### PR DESCRIPTION
#20 の修正

1. backendの`/api/admin/coupons`を修正 各クーポンは既存のクーポン情報 + user_countを返す
2. 管理画面のテーブルの表記も修正
3. プレースホルダの削除

user_count: 各クーポンが取得された回数

<img width="1185" alt="image" src="https://github.com/user-attachments/assets/15468834-aab2-4e73-8e81-be52f43a52ad" />
