### PR TITLE
Debug/management coupon dup del

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -568,7 +568,8 @@ body {
 .duplicate-btn,
 .delete-btn,
 .view-location-btn,
-.edit-btn {
+.edit-btn,
+.hard-delete-btn {
     padding: 6px 12px;
     border: none;
     border-radius: 6px;
@@ -604,6 +605,17 @@ body {
 
 .delete-btn:hover {
     background: #f8dbc1;
+}
+
+.hard-delete-btn {
+    background: #ffe6e6;
+    color: #cc3333;
+    font-weight: 600;
+}
+
+.hard-delete-btn:hover {
+    background: #ffcccc;
+    color: #aa2222;
 }
 
 .view-location-btn {

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -431,10 +431,15 @@ class AdminApp {
 
     initializeDefaultTimes() {
         const now = new Date();
-        const defaultEnd = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+        const defaultEnd = new Date(now.getTime() + 5 * 60 * 1000);
         
-        document.getElementById('start-time').value = now.toISOString().slice(0, 16);
-        document.getElementById('end-time').value = defaultEnd.toISOString().slice(0, 16);
+        // 日本時間に調整（UTC+9）
+        const jstOffset = 9 * 60 * 60 * 1000;
+        const nowJST = new Date(now.getTime() + jstOffset);
+        const defaultEndJST = new Date(defaultEnd.getTime() + jstOffset);
+        
+        document.getElementById('start-time').value = nowJST.toISOString().slice(0, 16);
+        document.getElementById('end-time').value = defaultEndJST.toISOString().slice(0, 16);
     }
 
     // Authentication handlers


### PR DESCRIPTION
This pull request introduces a new "hard delete" feature for coupons in the admin interface, allowing super administrators to permanently delete coupons from the database. It also includes improvements to time handling by adjusting for the Japanese Standard Time (JST) timezone. Below is a summary of the most important changes:

### Frontend Changes

* **Added "Hard Delete" Button in the Admin Interface**: A new button (`.hard-delete-btn`) was added to the UI, visible only to super administrators, for performing hard deletes. The button has custom styles and hover effects in `admin/admin.css`. [[1]](diffhunk://#diff-8eb035e5e71751f8884d1e18f72eeff3488bb6391daa35e0da962f66600d5395L571-R572) [[2]](diffhunk://#diff-8eb035e5e71751f8884d1e18f72eeff3488bb6391daa35e0da962f66600d5395R610-R620) [[3]](diffhunk://#diff-abec93005da0b7f672b4358df833247054445eff1bedf3e6d057670ef0063346R725-R729)
* **Improved Time Handling with JST Adjustment**: Updated the `initializeDefaultTimes` and `duplicateCoupon` methods in `admin/admin.js` to adjust default times to JST (UTC+9). This ensures that displayed times are localized for Japanese users. [[1]](diffhunk://#diff-abec93005da0b7f672b4358df833247054445eff1bedf3e6d057670ef0063346L434-R442) [[2]](diffhunk://#diff-abec93005da0b7f672b4358df833247054445eff1bedf3e6d057670ef0063346L1145-R1229)

### Backend Changes

* **Hard Delete Logic in API**: Modified the `delete_coupon` endpoint in `backend/api/admin_routes.py` to support hard deletes. Only super administrators can perform hard deletes, which permanently remove coupons and related data from the database. [[1]](diffhunk://#diff-4325c485c73d280fa8421a3eb3c51ed0af25b6c3fb778444e03e62a64511aa34R514-R518) [[2]](diffhunk://#diff-4325c485c73d280fa8421a3eb3c51ed0af25b6c3fb778444e03e62a64511aa34R531-R555)

These changes enhance the admin interface by providing more precise control over coupon deletion and improving time localization for better user experience.